### PR TITLE
Adding "TLS" to Registry Names

### DIFF
--- a/draft-ietf-tls-rfc8447bis.md
+++ b/draft-ietf-tls-rfc8447bis.md
@@ -83,7 +83,7 @@ and {{?RFC8447}} with {{!I-D.ietf-tls-rfc8447bis}}.
 # Adding "TLS" to Registry Names
 
 For consistency amongst TLS registries, IANA
-[SHALL prepend/has prepended] "TLS" to the following registries:
+has prepended "TLS" to the following registries:
 
 - Application-Layer Protocol Negotiation (ALPN) Protocol IDs {{!RFC7301}},
 - ExtensionType Values,


### PR DESCRIPTION
Clarifying IANA is only to update the reference in this section.