### PR TITLE
Fix some refe notations

### DIFF
--- a/draft-ietf-tls-rfc8447bis.md
+++ b/draft-ietf-tls-rfc8447bis.md
@@ -127,7 +127,7 @@ IANA SHALL update the TLS ExtensionType Values registry as follows:
     Values with the first byte in the range 0-254 (decimal) are assigned
     via Specification Required [RFC8126].  Values with the first byte
     255 (decimal) are reserved for Private Use [RFC8126].  Setting a
-    "Recommended" column value to Y or D requires Standards Action {{!RFC8126}}.
+    "Recommended" column value to Y or D requires Standards Action [RFC8126].
     Any state transition to or from a "Y" or "D" value requires
     IESG Approval.
 ~~~
@@ -165,7 +165,7 @@ IANA SHALL update the TLS ExtensionType Values registry as follows:
     assigned via Specification Required [RFC8126].  Values with the
     first byte 255 (decimal) are reserved for Private Use [RFC8126].
     Setting a "Recommended" column value to Y or D requires Standards
-    Action {{!RFC8126}}. Any state transition to or from a "Y" or "D"
+    Action [RFC8126]. Any state transition to or from a "Y" or "D"
     value requires IESG Approval.
 ~~~
 
@@ -238,7 +238,7 @@ IANA SHALL update the TLS Supported Groups registry as follows:
 
 ~~~
     Setting a "Recommended" column value to Y or D requires Standards
-    Action {{!RFC8126}}. Any state transition to or from a "Y" or "D"
+    Action [RFC8126]. Any state transition to or from a "Y" or "D"
     value requires IESG Approval.
 ~~~
 
@@ -263,7 +263,7 @@ IANA SHALL update the TLS Exporter Labels Registry as follows:
 
 ~~~
     Setting a "Recommended" column value to Y or D requires Standards
-    Action {{!RFC8126}}. Any state transition to or from a "Y" or "D"
+    Action [RFC8126]. Any state transition to or from a "Y" or "D"
     value requires IESG Approval.
 ~~~
 
@@ -303,7 +303,7 @@ IANA SHALL update the the TLS Certificate Types registry as follows:
     Required [RFC8126]. Values in the range 224-255 (decimal) are
     reserved for Private Use [RFC8126]. Setting a "Recommended" column
     value to Y or D requires Standards
-    Action {{!RFC8126}}. Any state transition to or from a "Y" or "D"
+    Action [RFC8126]. Any state transition to or from a "Y" or "D"
     value requires IESG Approval.
 ~~~
 
@@ -325,7 +325,7 @@ registry as follows:
 
 ~~~
     Setting a "Recommended" column value to Y or D requires Standards
-    Action {{!RFC8126}}. Any state transition to or from a "Y" or "D"
+    Action [RFC8126]. Any state transition to or from a "Y" or "D"
     value requires IESG Approval.
 ~~~
 
@@ -359,7 +359,7 @@ registry as follows:
 
 ~~~
     Setting a "Recommended" column value to Y or D requires Standards
-    Action {{!RFC8126}}. Any state transition to or from a "Y" or "D"
+    Action [RFC8126]. Any state transition to or from a "Y" or "D"
     value requires IESG Approval.
 ~~~
 
@@ -392,7 +392,7 @@ registry as follows:
 
 ~~~
     Setting a "Recommended" column value to Y or D requires Standards
-    Action {{!RFC8126}}. Any state transition to or from a "Y" or "D"
+    Action [RFC8126]. Any state transition to or from a "Y" or "D"
     value requires IESG Approval.
 ~~~
 
@@ -427,7 +427,7 @@ IANA SHALL update the TLS PskKeyExchangeMode registry as follows:
 
 ~~~
     Setting a "Recommended" column value to Y or D requires Standards
-    Action {{!RFC8126}}. Any state transition to or from a "Y" or "D"
+    Action [RFC8126]. Any state transition to or from a "Y" or "D"
     value requires IESG Approval.
 ~~~
 


### PR DESCRIPTION
Using the { } and notation in code snippets doesn't work.  Need to change to [ ].